### PR TITLE
Various fixes

### DIFF
--- a/projector.el
+++ b/projector.el
@@ -1,19 +1,23 @@
-;;;; projector.el --- a lightweight Emacs library for managing project/repository-aware shell and shell command buffers.
+;;; projector.el --- Lightweight library for managing project/repository-aware shell and command buffers
 ;;
 ;; Copyright 2013 Justin Talbott
 ;;
 ;; Author: Justin Talbott <justin@waymondo.com>
 ;; URL: https://github.com/waymondo/projector
 ;; Version: 0.1.0
+;; Keywords: processes
 ;; Package-Requires:
+;;
+;;; Commentary:
 ;;
 ;; Example Installation:
 ;;
 ;;   (require 'projector)
 ;;   (setq projector-projects-root "~/code/")
 ;;
+;;; Code:
 
-(eval-when-compile (require 'cl))
+(require 'cl)
 (autoload 'vc-git-root "vc-git")
 (autoload 'vc-svn-root "vc-svn")
 (autoload 'vc-hg-root "vc-hg")
@@ -30,7 +34,7 @@
 (require 'ido)
 (defvar projector-ido-no-complete-space nil)
 (defadvice ido-complete-space (around ido-insert-space activate)
-  "Allow space on keyboard to insert space when ido-ing shell commands"
+  "Allow space on keyboard to insert space when ido-ing shell commands."
   (if projector-ido-no-complete-space
       (insert " ")
     ad-do-it))
@@ -61,7 +65,7 @@
     (get-buffer (projector-shell-buffer-name))))
 
 (defun projector-notify (title message)
-  "Send shell command exit notification to `terminal-notifier', `growlnotify', or Emacs (message)"
+  "Send a notification with TITLE and MESSAGE to \"terminal-notifier\", \"growlnotify\", or `message'."
   (if (executable-find "terminal-notifier")
       (projector-notify-terminal-notifier title message)
     (if (executable-find "growlnotify")
@@ -105,37 +109,37 @@
          (projector-async-shell-command-get-buffer))))))
 
 ;;;###autoload
-(defun projector-run-shell-command-project-root (&optional arg)
+(defun projector-run-shell-command-project-root (&optional notify-on-exit)
   "Execute command from minibuffer at the projector root.
-  By default, it outputs into a dedicated buffer.
-  `C-u' prefix - execute command in the background
-  and send the exit message to `terminal-notifier', `growlnotify', or Emacs (message)."
+By default, it outputs into a dedicated buffer.
+With the optional argument NOTIFY-ON-EXIT, execute command in the background
+and send the exit message as a notification."
   (interactive "P")
   (let ((dir-string (concat (projector-project-name) " root")))
-    (projector-run-command-buffer nil (consp arg) dir-string)))
+    (projector-run-command-buffer nil (consp notify-on-exit) dir-string)))
 
 ;;;###autoload
 (defun projector-run-shell-command-project-root-background ()
-  "Execute command from minibuffer at the projector root in the background
-  and send the exit message to `terminal-notifier', `growlnotify', or Emacs (message)."
+  "Execute command from minibuffer at the projector root in the background.
+Sends the exit message as a notification."
   (interactive)
   (let ((dir-string (concat (projector-project-name) " root")))
     (projector-run-command-buffer nil t dir-string)))
 
 ;;;###autoload
-(defun projector-run-shell-command-current-directory (&optional arg)
-  "Execute command from minibuffer in the current directory
-  By default, it outputs into a dedicated buffer.
-  `C-u' prefix - execute command in the background
-  and send the exit message to `terminal-notifier', `growlnotify', or Emacs (message)."
+(defun projector-run-shell-command-current-directory (&optional notify-on-exit)
+  "Execute command from minibuffer in the current directory.
+By default, it outputs into a dedicated buffer.
+With the optional argument NOTIFY-ON-EXIT, execute command in the background
+and send the exit message as a notification."
   (interactive "P")
   (let ((dir-string "current-directory"))
-    (projector-run-command-buffer t (consp arg) dir-string)))
+    (projector-run-command-buffer t (consp notify-on-exit) dir-string)))
 
 ;;;###autoload
 (defun projector-run-shell-command-current-directory-background ()
-  "Execute command from minibuffer in the current directory
-  and send the exit message to `terminal-notifier', `growlnotify', or Emacs (message)."
+  "Execute command from minibuffer in the current directory.
+Sends the exit message as a notification."
   (interactive)
   (let ((dir-string "current-directory"))
     (projector-run-command-buffer t t dir-string)))
@@ -193,3 +197,4 @@
      (ido-completing-read "Projector Shell Buffer: " (projector-shell-buffers)))))
 
 (provide 'projector)
+;;; projector.el ends here


### PR DESCRIPTION
(In connection with https://github.com/milkypostman/melpa/pull/1132)
- Fix header and trailing lines
- Add missing keywords header
- Require 'cl at runtime, not compile-time, for delete-duplicates
- Only use `' quoting for lisp symbols
- More closely follow checkdoc guidelines for docstrings
- Add missing defvar for command history

In general, you should enable `auto-insert-mode', which will prompt you to interactively insert a standard skeleton for new emacs lisp files -- the resulting layout will be automatically compatible with`package.el`, which this was not. Also, turn on`checkdoc-mode` to get nagged about docstrings. It helps make sure you follow the guidelines for elisp documentation.

Regarding the code itself, you might consider using John Wiegley's `alert` library, or even `todochiku` in order to display platform-aware notifications.

Cheers!

-Steve
