### PR TITLE
fix "void-function ivy-set-actions"

### DIFF
--- a/projector.el
+++ b/projector.el
@@ -153,11 +153,12 @@ This is usually most helpful to set on a directoy local level via a
 https://github.com/abo-abo/swiper")))
      (t (funcall projector-completion-system prompt choices)))))
 
-(ivy-set-actions
- 'projector-run-command-buffer-prompt
- '(("D" (lambda (cmd)
-          (delete cmd projector-command-history))
-    "remove from history")))
+(with-eval-after-load "ivy"
+  (ivy-set-actions
+   'projector-run-command-buffer-prompt
+   '(("D" (lambda (cmd)
+            (delete cmd projector-command-history))
+      "remove from history"))))
 
 ;;;###autoload
 (defun projector-rerun-buffer-process ()


### PR DESCRIPTION
The function `ivy-set-actions` isn't defined if ivy isn't loaded.  Since ivy isn't a dependency, it would be good to wrap that code in `with-eval-after-load` (or an `eval-after-load` if you want to support emacs <24.4).